### PR TITLE
Return 404 if package id for /info endpoint isn't found

### DIFF
--- a/dev_server.py
+++ b/dev_server.py
@@ -1,4 +1,3 @@
 from os_api.app import app
 
 app.run(port=8000, debug=True)
-

--- a/os_api/info_api.py
+++ b/os_api/info_api.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, current_app
+from flask import Blueprint, current_app, abort
 from flask.ext.jsonpify import jsonify
 
 infoAPI = Blueprint('InfoAPI', __name__)
@@ -9,3 +9,5 @@ def get_package(slug):
     mr = current_app.extensions['model_registry']
     if mr.has_model(slug):
         return jsonify(mr.get_package(slug))
+    else:
+        abort(404)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,8 @@ class TestAPI(object):
         assert res.json['status'] == 'ok'
         res = client.get('/api/3/cubes/')
         assert res.status_code == 200
-        assert '__testing:ukgov-finances-cra' in [i['name'] for i in res.json['data']]
+        assert '__testing:ukgov-finances-cra' \
+            in [i['name'] for i in res.json['data']]
 
     def test_package_inspection_configured_success(self, client):
         res = client.get('/api/3/info/__testing:ukgov-finances-cra/package')
@@ -24,20 +25,22 @@ class TestAPI(object):
 
     @pytest.mark.skip
     def test_loader_and_backward_compatibility_api_success(self, client):
-        responses = zipfile.ZipFile('tests/backward_responses.zip','r')
+        responses = zipfile.ZipFile('tests/backward_responses.zip', 'r')
         for path in responses.namelist():
             canned_response = json.loads(responses.read(path).decode('utf8'))
-            path = path.replace('=ukgov-finances-cra','=__testing:ukgov-finances-cra')
+            path = path.replace('=ukgov-finances-cra',
+                                '=__testing:ukgov-finances-cra')
             actual_response = client.get(path).json
             errors = compare_objects(canned_response, actual_response)
-            if len(errors)>0:
-                print('URL:\n',path)
-                print('Expected:\n',canned_response)
-                print('Actual:\n',actual_response)
+            if len(errors) > 0:
+                print('URL:\n', path)
+                print('Expected:\n', canned_response)
+                print('Actual:\n', actual_response)
             assert len(errors) == 0
 
     def test_loader_and_backward_compatibility_api_errors(self, client):
-        responses = zipfile.ZipFile('tests/backward_mismatch_responses.zip','r')
+        responses = \
+            zipfile.ZipFile('tests/backward_mismatch_responses.zip', 'r')
         for path in responses.namelist():
             canned_response = json.loads(responses.read(path).decode('utf8'))
             actual_response = client.get(path).json
@@ -47,54 +50,68 @@ class TestAPI(object):
 
 @pytest.fixture(scope='module')
 def load_sample_fdp_to_db(elasticsearch):
-    DATAPACKAGE_URL = "https://raw.githubusercontent.com/akariv/openspending-migrate/" \
-                      "adam__test_datetime_dimension_change/examples/ukgov-finances-cra/datapackage.json"
+    DATAPACKAGE_URL = "https://raw.githubusercontent.com/akariv/openspending-migrate/adam__test_datetime_dimension_change/examples/ukgov-finances-cra/datapackage.json"  # noqa
 
     loader = babbage_fiscal.FDPLoader(engine=config.get_engine())
     loader.load_fdp_to_db(DATAPACKAGE_URL)
 
 
-def compare_objects(o1,o2,prefix=''):
+def compare_objects(o1, o2, prefix=''):
     allowed_missing_keys = {'cached', 'cache_key'}
-    allowed_value_mismatch_keys = {'name', 'color', 'label', 'num_entries','errors', 'html_url','id'}
-    err=[]
+    allowed_value_mismatch_keys = {'name', 'color', 'label', 'num_entries',
+                                   'errors', 'html_url', 'id'}
+    err = []
     k1 = set(o1.keys())
     k2 = set(o2.keys())
-    if len(k1-k2-allowed_missing_keys)>0:
+    if len(k1-k2-allowed_missing_keys) > 0:
         err.append("Keys in 1st and not in 2nd: %s" % ", ".join(list(k1-k2)))
-    if len(k2-k1-allowed_missing_keys)>0:
+    if len(k2-k1-allowed_missing_keys) > 0:
         err.append("Keys in 2st and not in 1st: %s" % ", ".join(list(k2-k1)))
     for k in k1:
         if k in k2:
             v1 = o1[k]
             v2 = o2[k]
             if type(v1) == type(v2):
-                if type(v1) in six.string_types or type(v1) is six.text_type or type(v1) in six.integer_types or type(v1) in (float, bool):
+                if type(v1) in six.string_types \
+                   or type(v1) is six.text_type \
+                   or type(v1) in six.integer_types \
+                   or type(v1) in (float, bool):
                     if v1 != v2:
                         if k not in allowed_value_mismatch_keys:
                             if type(v1) is float:
-                                if abs(v1 - v2)>1:
-                                    err.append("Values for %s/%s are too different (%r,%r)" % (prefix,k,v1,v2))
+                                if abs(v1 - v2) > 1:
+                                    msg = "Values for %s/%s are too " \
+                                          "different (%r,%r)"
+                                    err.append(msg % (prefix, k, v1, v2))
                             else:
-                                err.append("Values for %s/%s are different (%r,%r)" % (prefix,k,v1,v2))
+                                msg = "Values for %s/%s are different (%r,%r)"
+                                err.append(msg % (prefix, k, v1, v2))
                 elif type(v1) is list:
                     if len(v1) != len(v2):
-                        err.append("Lengths for %s/%s are different (%r,%r)" % (prefix,k,len(v1),len(v2)))
+                        msg = "Lengths for %s/%s are different (%r,%r)"
+                        err.append(msg % (prefix, k, len(v1), len(v2)))
                     else:
                         errs_in_list = 0
                         for i in range(len(v1)):
                             if type(v1[i]) is dict and type(v2[i]) is dict:
-                                errs = TestAPI.compare_objects(v1[i],v2[i],prefix+'/%s[%d]' % (k,i))
+                                errs = TestAPI.compare_objects(
+                                    v1[i],
+                                    v2[i],
+                                    prefix + '/%s[%d]' % (k, i))
                             else:
-                                errs = [] if v1[i] == v2[i] else ['Item mismatch: %r != %r' % (v1[i],v2[i])]
-                            if len(errs)>0:
+                                errs = [] if v1[i] == v2[i] \
+                                          else ['Item mismatch: %r != %r' % (v1[i], v2[i])]  # noqa
+                            if len(errs) > 0:
                                 err.extend(errs)
-                                errs_in_list+=1
+                                errs_in_list += 1
                                 if errs_in_list == 3:
-                                    err.append('more than 3 errors in list %s' % prefix)
+                                    msg = 'more than 3 errors in list %s'
+                                    err.append(msg % prefix)
                                     break
                 else:
-                    err.extend(TestAPI.compare_objects(v1,v2,prefix+'/%s' % k))
+                    err.extend(TestAPI.compare_objects(
+                        v1, v2, prefix+'/%s' % k))
             else:
-                err.append("Types for %s/%s are different (%r,%r)" % (prefix,k,v1,v2))
+                msg = "Types for %s/%s are different (%r,%r)"
+                err.append(msg % (prefix, k, v1, v2))
     return err

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,6 +23,10 @@ class TestAPI(object):
         assert res.status_code == 200
         assert res.json['name'] == 'ukgov-finances-cra'
 
+    def test_package_inspection_configured_notfound(self, client):
+        res = client.get('/api/3/info/__testing:no-package-here/package')
+        assert res.status_code == 404
+
     @pytest.mark.skip
     def test_loader_and_backward_compatibility_api_success(self, client):
         responses = zipfile.ZipFile('tests/backward_responses.zip', 'r')


### PR DESCRIPTION
Currently, the view function doesn't return a valid response if a model isn't found for the `slug`. This PR aborts the response with a 404. 

Fixes openspending/openspending#1331.