### PR TITLE
Use dpp-runner instead of babbage-fiscal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,12 @@ before_install:
   - nvm install 8
   - nvm use 8
   - npm install -g os-types
-  - sudo apt-get install libleveldb-dev libleveldb1
+  - sudo apt-get install libleveldb-dev libleveldb1 libpq-dev python3-dev
 
 install:
   # Will build local Dockerfile as part of ci-run (docker-compose up)
   - make ci-run
-  - pip install tox coveralls datapackage-pipelines[speedup] datapackage-pipelines-fiscal
+  - pip install tox coveralls datapackage-pipelines[speedup] datapackage-pipelines-fiscal psycopg2
 
 before_script:
   - sleep 30

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
 env:
     global:
         - OS_API_ENGINE=postgresql://postgres@/postgres
+        - DPP_DB_ENGINE=postgresql://postgres@/postgres
         - OS_ELASTICSEARCH_ADDRESS=localhost:9200
         # DOCKER_USERNAME
         - secure: stuHESFXIArG1T1u4ddSwOsrNMjQ9TSAw/UYdWqs5rdkkBz+tYA2S0f8fqpE7kLffwcsnie0lWAuF5HpGWsb42ZAgDnY8ENJBds+65378uT7CepsM+A4GkLdSYGQTgrhTgAmbLJtBIt4vzELisW2V/G2rSlrfS1OjQZKaDeoqXQLOslCE/05oKFvyYw1YN4fpPFqjJVeBNBqXmVYSjBz7CrinUcxQfqUhMqGfgF7VgjTO4Jt+vKU4ym3nKgqyRufYWbgmbEoevi/3JAHuWx73kCv7MVnQQaBdyXdPLQLLqmR/PSxkUsAfH+rUWdam+mF3txB9si+Pw17LUaV+hnVJ+N8zpOTIkxN1bDHilWWdrw52lM5n/7//uBABAa2DZO2+8F2o7oh1sH5anKCRv48dvpboRsqoG+ymnGsDv01QlgcWcZ8hcj8KOC6kmbnjNK9hCk+WywWKo2LSs8+FfD/fTfBeUPKB1lPLFn64DzpOLGzbAUhvQ7bsP+Py1awf6ClcHgSXvWdJQTEuOGr8eJ7zPXE4BC2+tWXEDM+0rOiF2saGqXzQqS5BGmtvtk+U7ujquFSfYm038PLl7uYU+pdBRSI3p5rC1aAWYaPayyGUnnZwK3rMta/ih/GVM6LZtdkXn1wVHitjrDRVTdVF/jwZN7vzltjmormMMPAKWIHK9Q=

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 install:
   # Will build local Dockerfile as part of ci-run (docker-compose up)
   - make ci-run
-  - pip install tox coveralls
+  - pip install tox coveralls datapackage-pipelines datapackage-pipelines-fiscal
 
 before_script:
   - sleep 30
@@ -37,6 +37,7 @@ before_script:
 
 script:
   - make ci-test
+  - cd tests/sample_data && ls && dpp && dpp run --verbose all
   - tox
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ env:
 before_install:
   - sudo rm -f /etc/boto.cfg
   - curl -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.5.2.deb && sudo dpkg -i --force-confnew elasticsearch-1.5.2.deb && sudo service elasticsearch restart
+  - nvm install 8
+  - nvm use 8
+  - npm install -g os-types
 
 install:
   # Will build local Dockerfile as part of ci-run (docker-compose up)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language:
   python
 
@@ -6,6 +8,8 @@ python:
 
 services:
   - docker
+
+sudo: required
 
 addons:
     postgresql: "9.4"
@@ -25,11 +29,12 @@ before_install:
   - nvm install 8
   - nvm use 8
   - npm install -g os-types
+  - sudo apt-get install libleveldb-dev libleveldb1
 
 install:
   # Will build local Dockerfile as part of ci-run (docker-compose up)
   - make ci-run
-  - pip install tox coveralls datapackage-pipelines datapackage-pipelines-fiscal
+  - pip install tox coveralls datapackage-pipelines[speedup] datapackage-pipelines-fiscal
 
 before_script:
   - sleep 30

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
 install:
   # Will build local Dockerfile as part of ci-run (docker-compose up)
   - make ci-run
-  - pip install tox coveralls datapackage-pipelines[speedup] datapackage-pipelines-fiscal psycopg2
+  - pip install tox coveralls datapackage-pipelines[speedup] datapackage-pipelines-fiscal psycopg2-binary
 
 before_script:
   - sleep 30

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
         - OS_API_ENGINE=postgresql://postgres@/postgres
         - DPP_DB_ENGINE=postgresql://postgres@/postgres
         - OS_ELASTICSEARCH_ADDRESS=localhost:9200
+        - ELASTICSEARCH_ADDRESS=localhost:9200
         # DOCKER_USERNAME
         - secure: stuHESFXIArG1T1u4ddSwOsrNMjQ9TSAw/UYdWqs5rdkkBz+tYA2S0f8fqpE7kLffwcsnie0lWAuF5HpGWsb42ZAgDnY8ENJBds+65378uT7CepsM+A4GkLdSYGQTgrhTgAmbLJtBIt4vzELisW2V/G2rSlrfS1OjQZKaDeoqXQLOslCE/05oKFvyYw1YN4fpPFqjJVeBNBqXmVYSjBz7CrinUcxQfqUhMqGfgF7VgjTO4Jt+vKU4ym3nKgqyRufYWbgmbEoevi/3JAHuWx73kCv7MVnQQaBdyXdPLQLLqmR/PSxkUsAfH+rUWdam+mF3txB9si+Pw17LUaV+hnVJ+N8zpOTIkxN1bDHilWWdrw52lM5n/7//uBABAa2DZO2+8F2o7oh1sH5anKCRv48dvpboRsqoG+ymnGsDv01QlgcWcZ8hcj8KOC6kmbnjNK9hCk+WywWKo2LSs8+FfD/fTfBeUPKB1lPLFn64DzpOLGzbAUhvQ7bsP+Py1awf6ClcHgSXvWdJQTEuOGr8eJ7zPXE4BC2+tWXEDM+0rOiF2saGqXzQqS5BGmtvtk+U7ujquFSfYm038PLl7uYU+pdBRSI3p5rC1aAWYaPayyGUnnZwK3rMta/ih/GVM6LZtdkXn1wVHitjrDRVTdVF/jwZN7vzltjmormMMPAKWIHK9Q=
         # DOCKER_PASSWORD

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
 
 script:
   - make ci-test
-  - cd tests/sample_data && ls && dpp && dpp run --verbose all
+  - cd tests/sample_data && ls && dpp && dpp run --verbose --concurrency=8 all
   - tox
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -36,9 +36,30 @@ A development server can be started with:
 
 ## Testing
 
-Make sure you have a local ElasticSearch instance running on `localhost:9200`,
-and run:
+You need a few services running, namely elasticsearch v1.5 running on localhost:9200 and PostgreSQL
 
+
+Then set a few environment variables (your DB connection string might vary):
+```bash
+$ export OS_API_ENGINE=postgresql://postgres@/postgres
+$ export DPP_DB_ENGINE=postgresql://postgres@/postgres
+$ export OS_ELASTICSEARCH_ADDRESS=localhost:9200
+$ export ELASTICSEARCH_ADDRESS=localhost:9200
 ```
+
+Install a few dependencies:
+```bash
+$ npm install -g os-types
+$ sudo apt-get install libleveldb-dev libleveldb1 libpq-dev python3-dev
+$ pip3 install tox coveralls datapackage-pipelines[speedup] datapackage-pipelines-fiscal psycopg2-binary
+```
+
+Fill the local DB with a sample fiscal data:
+```
+$ cd tests/sample_data && dpp run --verbose --concurrency=8 all
+```
+
+Then run:
+```bash
 $ tox
 ```

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,28 +1,7 @@
 #!/bin/sh
 set -e
 
-ls $WORKDIR/.git > /dev/null && cd $WORKDIR || cd /app
-echo working from `pwd`
+cd /app
 echo OS-API DB: $OS_API_ENGINE
 
-if [ ! -z "$GIT_REPO" ]; then
-    rm -rf /remote || true && git clone $GIT_REPO /remote && cd /remote;
-    if [ ! -z "$GIT_BRANCH" ]; then
-        git checkout origin/$GIT_BRANCH
-    fi
-    pip install -U -r requirements.txt
-else
-    (cd /repos/babbage.fiscal-data-package && pip3 install -U -e . && echo using `pwd` dev version) || true
-    (cd /repos/babbage && pip3 install -U -e . && echo using `pwd` dev version) || true
-    (cd /repos/datapackage-py && pip3 install -U -e . && echo using `pwd` dev version) || true
-    (cd /repos/tabulator-py && pip3 install -U -e . && echo using `pwd` dev version) || true
-    (cd /repos/jsontableschema-py && pip3 install -U -e . && echo using `pwd` dev version) || true
-    (cd /repos/jsontableschema-sql-py && pip3 install -U -e . && echo using `pwd` dev version) || true
-fi
-
-python3 --version
-if [ ! -z "$OS_API_LOADER" ]; then
-    FISCAL_PACKAGE_ENGINE=$OS_API_ENGINE bb-fdp-cli create-tables && echo "CREATED TABLES"
-    python3 -m celery --concurrency=4 -A babbage_fiscal.tasks -l INFO worker &
-fi
 gunicorn -t 120 -w 4 os_api.app:app -b 0.0.0.0:8000

--- a/os_api/app.py
+++ b/os_api/app.py
@@ -45,20 +45,20 @@ def create_app():
     _app = Flask('os_api')
     _app.wsgi_app = ProxyFix(_app.wsgi_app)
 
-    manager = OSCubeManager(get_engine())
+    registry = PackageRegistry(es_connection_string=os.environ.get('OS_ELASTICSEARCH_ADDRESS','localhost:9200'))
+    manager = OSCubeManager(get_engine(), registry)
 
     logging.info('OS-API configuring query blueprints')
     _app.register_blueprint(configure_babbage_api(_app, manager), url_prefix='/api/3')
     _app.register_blueprint(configure_backward_api(_app, manager), url_prefix='/api/2')
     _app.register_blueprint(infoAPI, url_prefix='/api/3')
 
-    _app.extensions['model_registry'] = PackageRegistry(es_connection_string=os.environ.get('OS_ELASTICSEARCH_ADDRESS','localhost:9200'))
-    _app.extensions['loader'] = loader
+    _app.extensions['model_registry'] = registry
 
     CORS(_app)
     Sentry(_app, dsn=os.environ.get('SENTRY_DSN', ''))
 
-    logging.info('OS-API app created (loader=%s)', loader)
+    logging.info('OS-API app created')
     return _app
 
 

--- a/os_api/cube_manager.py
+++ b/os_api/cube_manager.py
@@ -1,11 +1,10 @@
 from babbage import CubeManager
-from babbage_fiscal import ModelRegistry
 
 class OSCubeManager(CubeManager):
 
-    def __init__(self,engine):
+    def __init__(self, engine, registry):
         super(OSCubeManager, self).__init__(engine)
-        self.registry = ModelRegistry()
+        self.registry = registry
 
     def list_cubes(self):
         """ List all available models in the DB """

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ python-memcached
 awesome-slugify
 regex
 datadog
+elasticsearch>=1,<2
 flask-cors
 flask-jsonpify
 sqlalchemy
@@ -12,7 +13,7 @@ six
 raven==6.0.0
 redis
 os-api-cache>=0.0.2
-babbage_fiscal>=0.0.10
+os-package-registry==0.0.12
 babbage>=0.3.5
 datapackage>=1.0.0,<2
 tableschema>=1.0.0,<2

--- a/requirements.in
+++ b/requirements.in
@@ -18,6 +18,6 @@ babbage>=0.3.5
 datapackage>=1.0.0,<2
 tableschema>=1.0.0,<2
 tableschema-sql>=0.9.0,<2
-tabulator>=1.0.0,<2
+tabulator>=1.10.0,<2
 blinker>=1.1
 python-dotenv

--- a/requirements.in
+++ b/requirements.in
@@ -13,11 +13,11 @@ six
 raven==6.0.0
 redis
 os-api-cache>=0.0.2
-os-package-registry==0.0.12
+os-package-registry>=0.0.12
 babbage>=0.3.5
 datapackage>=1.0.0,<2
 tableschema>=1.0.0,<2
-tableschema-sql>=0.9.0,<2
+tableschema-sql>=0.10.0,<2
 tabulator>=1.10.0,<2
 blinker>=1.1
 python-dotenv

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ raven==6.0.0
 redis
 os-api-cache>=0.0.2
 babbage_fiscal>=0.0.10
-babbage>=0.3.3
+babbage>=0.3.5
 datapackage>=1.0.0,<2
 tableschema>=1.0.0,<2
 tableschema-sql>=0.9.0,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 amqp==2.2.2               # via kombu
 awesome-slugify==1.6.5
 babbage-fiscal==0.0.10
-babbage==0.3.3
+babbage==0.3.5
 billiard==3.5.0.3         # via celery
 bitarray==0.8.1           # via pybloom-live
 blinker==1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ six==1.11.0
 sqlalchemy==1.1.14
 tableschema-sql==0.10.0
 tableschema==1.0.3
-tabulator==1.5.0
+tabulator==1.14.0
 unicodecsv==0.14.1        # via datapackage, tableschema, tabulator
 unidecode==0.4.21         # via awesome-slugify
 urllib3==1.22             # via elasticsearch, requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,68 +4,59 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-amqp==2.2.2               # via kombu
 awesome-slugify==1.6.5
-babbage-fiscal==0.0.10
 babbage==0.3.5
-billiard==3.5.0.3         # via celery
 bitarray==0.8.1           # via pybloom-live
 blinker==1.4
 cchardet==1.1.3
-celery==4.1.0             # via babbage-fiscal
 certifi==2017.7.27.1      # via requests
 chardet==3.0.4            # via normality, requests
-click==6.7                # via babbage-fiscal, datapackage, flask, jsontableschema, python-dotenv, tableschema, tabulator
+click==6.7                # via datapackage, flask, python-dotenv, tableschema, tabulator
 contextlib2==0.5.5        # via raven
 datadog==0.16.0
 datapackage==1.0.4
 decorator==4.1.2          # via datadog
-elasticsearch==1.9.0      # via babbage-fiscal, os-package-registry
+elasticsearch==1.9.0
 et-xmlfile==1.0.1         # via openpyxl
 flask-cors==3.0.3
 flask-jsonpify==1.5.0
 flask==0.12.2             # via babbage, flask-cors, flask-jsonpify
-future==0.16.0            # via jsontableschema
 grako==3.10.1             # via babbage
 gunicorn==19.7.1
 idna==2.6                 # via requests
 ijson==2.3                # via tabulator
-isodate==0.5.4            # via jsontableschema, tableschema
+isodate==0.5.4            # via tableschema
 itsdangerous==0.24        # via flask
 jdcal==1.3                # via openpyxl
 jinja2==2.9.6             # via flask
 jsonlines==1.2.0          # via tabulator
 jsonpointer==1.12         # via datapackage
-jsonschema==2.6.0         # via babbage, datapackage, jsontableschema, tableschema
-jsontableschema==0.10.1   # via babbage-fiscal
-kombu==4.1.0              # via celery
+jsonschema==2.6.0         # via babbage, datapackage, tableschema
 linear-tsv==1.0.0         # via tabulator
 markupsafe==1.0           # via jinja2
 normality==0.4.4          # via babbage
 openpyxl==2.4.8           # via tabulator
 os-api-cache==0.0.5
-os-package-registry==0.0.12  # via babbage-fiscal
+os-package-registry==0.0.12
 psycopg2==2.7.3.1
 pybloom-live==2.3.1       # via tableschema-sql
-python-dateutil==2.6.1    # via jsontableschema, tableschema
+python-dateutil==2.6.1    # via tableschema
 python-dotenv==0.7.1
 python-memcached==1.58
-pytz==2017.2              # via celery
 pyyaml==3.12              # via babbage
 raven==6.0.0
 redis==2.10.6
 regex==2017.9.23
-requests==2.18.4          # via datadog, datapackage, jsontableschema, tableschema, tabulator
-rfc3986==0.4.1            # via jsontableschema, tableschema
+requests==2.18.4          # via datadog, datapackage, tableschema, tabulator
+rfc3986==0.4.1            # via tableschema
 simplejson==3.11.1        # via datadog
 six==1.11.0
 sqlalchemy==1.1.14
 tableschema-sql==0.10.0
 tableschema==1.0.3
 tabulator==1.5.0
-unicodecsv==0.14.1        # via datapackage, jsontableschema, tableschema, tabulator
+unicodecsv==0.14.1        # via datapackage, tableschema, tabulator
 unidecode==0.4.21         # via awesome-slugify
 urllib3==1.22             # via elasticsearch, requests
-vine==1.1.4               # via amqp
 werkzeug==0.12.2          # via flask
 xlrd==1.1.0               # via tabulator

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ chardet==3.0.4            # via normality, requests
 click==6.7                # via datapackage, flask, python-dotenv, tableschema, tabulator
 contextlib2==0.5.5        # via raven
 datadog==0.16.0
-datapackage==1.0.4
+datapackage==1.2.3
 decorator==4.1.2          # via datadog
 elasticsearch==1.9.0
 et-xmlfile==1.0.1         # via openpyxl
@@ -48,12 +48,12 @@ raven==6.0.0
 redis==2.10.6
 regex==2017.9.23
 requests==2.18.4          # via datadog, datapackage, tableschema, tabulator
-rfc3986==0.4.1            # via tableschema
+rfc3986==1.1.0            # via tableschema
 simplejson==3.11.1        # via datadog
 six==1.11.0
 sqlalchemy==1.1.14
 tableschema-sql==0.10.0
-tableschema==1.0.3
+tableschema==1.0.12
 tabulator==1.14.0
 unicodecsv==0.14.1        # via datapackage, tableschema, tabulator
 unidecode==0.4.21         # via awesome-slugify

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import os
 from elasticsearch import Elasticsearch
 import pytest
 
-import babbage_fiscal
 from os_api.app import create_app
 
 

--- a/tests/sample_data/.gitignore
+++ b/tests/sample_data/.gitignore
@@ -1,0 +1,6 @@
+.dpp
+denormalized/
+normalized/
+final/
+.cache/
+__testing:ukgov_finances_cra_final.zip

--- a/tests/sample_data/fiscal.source-spec.yaml
+++ b/tests/sample_data/fiscal.source-spec.yaml
@@ -1,0 +1,67 @@
+dataset-name: ukgov-finances-cra
+resource-name: dataset
+title: UK Country Regional Analysis
+owner-id: __testing
+description: |
+  The Country Regional Analysis published by HM Treasury (2010 version).
+  
+  Source data can be found in the [CKAN data package](http://ckan.net/package/ukgov-finances-cra)
+ 
+sources:
+-
+  url: dataset.csv.gz
+  compression: gz
+
+fields:
+  - header: cofog1_label
+    osType: functional-classification:generic:level1:label
+  - header: cofog1_name
+    osType: functional-classification:generic:level1:code
+  - header: cofog2_label
+    osType: functional-classification:generic:level2:label
+  - header: cofog2_name
+    osType: functional-classification:generic:level2:code:full
+  - header: cofog3_label
+    osType: functional-classification:generic:level3:label
+  - header: cofog3_name
+    osType: functional-classification:generic:level3:code:full
+  - header: hmt1_label
+    osType: administrative-classification:generic:level1:label
+  - header: hmt1_name
+    osType: administrative-classification:generic:level1:code
+  - header: hmt2_label
+    osType: administrative-classification:generic:level1:label
+  - header: hmt2_name
+    osType: administrative-classification:generic:level1:code
+  - header: cg_lg_or_pc_label
+    osType: value-kind:label
+  - header: cg_lg_or_pc_name
+    osType: value-kind:code
+  - header: pog_label
+    osType: activity:generic:program:label
+  - header: pog_name
+    osType: activity:generic:program:code
+  - header: to_label
+    osType: recipient:generic:name
+  - header: to_name
+    osType: recipient:generic:id
+  - header: from_gov_department
+    osType: administrative-classification:generic:level3:code:full
+  - header: cap_or_cur_label
+    osType: economic-classification:generic:level1:label
+  - header: cap_or_cur_name
+    osType: economic-classification:generic:level1:code
+  - header: region_label
+    osType: administrative-classification:generic:level4:label
+  - header: region_name
+    osType: administrative-classification:generic:level4:code:full
+  - header: from_label
+    osType: administrative-classification:generic:level5:label
+  - header: from_name
+    osType: administrative-classification:generic:level5:code:full
+  - header: amount
+    osType: value
+  - header: time_year
+    osType: date:fiscal-year
+
+deduplicate: true

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ import json
 import six
 import pytest
 import os
+import logging
 
 from os_api import config
 
@@ -57,7 +58,8 @@ class TestAPI(object):
 @pytest.fixture(scope='module')
 def load_sample_fdp_to_db(elasticsearch):
     os.environ['DPP_DB_ENGINE'] = config._connection_string
-    run_pipelines('all', os.path.join(os.path.dirname(__file__), 'sample_data'))
+    run_pipelines('all', os.path.join(os.path.dirname(__file__), 'sample_data'),
+                  progress_cb=lambda x: logging.info('fixture progress %r', x))
 
 
 def compare_objects(o1, o2, prefix=''):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,10 +7,7 @@ import logging
 
 from os_api import config
 
-from datapackage_pipelines.manager.runner import run_pipelines
 
-
-@pytest.mark.usefixtures('load_sample_fdp_to_db')
 class TestAPI(object):
     def test_babbage_api_configured_success(self, client):
         res = client.get('/api/3/')
@@ -53,13 +50,6 @@ class TestAPI(object):
             actual_response = client.get(path).json
             errors = compare_objects(canned_response, actual_response)
             assert len(errors) > 0
-
-
-@pytest.fixture(scope='module')
-def load_sample_fdp_to_db(elasticsearch):
-    os.environ['DPP_DB_ENGINE'] = config._connection_string
-    run_pipelines('all', os.path.join(os.path.dirname(__file__), 'sample_data'),
-                  progress_cb=lambda x: logging.info('fixture progress %r', x))
 
 
 def compare_objects(o1, o2, prefix=''):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,9 +2,11 @@ import zipfile
 import json
 import six
 import pytest
+import os
 
-import babbage_fiscal
 from os_api import config
+
+from datapackage_pipelines.manager.runner import run_pipelines
 
 
 @pytest.mark.usefixtures('load_sample_fdp_to_db')
@@ -54,10 +56,8 @@ class TestAPI(object):
 
 @pytest.fixture(scope='module')
 def load_sample_fdp_to_db(elasticsearch):
-    DATAPACKAGE_URL = "https://raw.githubusercontent.com/akariv/openspending-migrate/adam__test_datetime_dimension_change/examples/ukgov-finances-cra/datapackage.json"  # noqa
-
-    loader = babbage_fiscal.FDPLoader(engine=config.get_engine())
-    loader.load_fdp_to_db(DATAPACKAGE_URL)
+    os.environ['DPP_DB_ENGINE'] = config._connection_string
+    run_pipelines('all', os.path.join(os.path.dirname(__file__), 'sample_data'))
 
 
 def compare_objects(o1, o2, prefix=''):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,13 +15,13 @@ class TestAPI(object):
         assert res.json['status'] == 'ok'
         res = client.get('/api/3/cubes/')
         assert res.status_code == 200
-        assert '__testing:ukgov-finances-cra' \
+        assert '__testing:ukgov_finances_cra' \
             in [i['name'] for i in res.json['data']]
 
     def test_package_inspection_configured_success(self, client):
-        res = client.get('/api/3/info/__testing:ukgov-finances-cra/package')
+        res = client.get('/api/3/info/__testing:ukgov_finances_cra/package')
         assert res.status_code == 200
-        assert res.json['name'] == 'ukgov-finances-cra'
+        assert res.json['name'] == 'ukgov_finances_cra'
 
     def test_package_inspection_configured_notfound(self, client):
         res = client.get('/api/3/info/__testing:no-package-here/package')
@@ -33,7 +33,7 @@ class TestAPI(object):
         for path in responses.namelist():
             canned_response = json.loads(responses.read(path).decode('utf8'))
             path = path.replace('=ukgov-finances-cra',
-                                '=__testing:ukgov-finances-cra')
+                                '=__testing:ukgov_finances_cra')
             actual_response = client.get(path).json
             errors = compare_objects(canned_response, actual_response)
             if len(errors) > 0:

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ deps =
   pytest-cov
   pytest-flask
   coverage
+  datapackage-pipelines
+  datapackage-pipelines-fiscal
 commands =
   pytest \
     --cov os_api \

--- a/tox.ini
+++ b/tox.ini
@@ -16,5 +16,6 @@ deps =
   datapackage-pipelines-fiscal
 commands =
   pytest \
+    -svv
     --cov os_api \
     {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,6 @@ deps =
   datapackage-pipelines-fiscal
 commands =
   pytest \
-    -svv
+    -svv \
     --cov os_api \
     {posargs}


### PR DESCRIPTION
This is a bit thin, as most of the modifications were done in babbage.

The main change there is to support a slight change to the babbage model syntax for supporting joins between two DB tables.

It used to support a simple `"join-column": "bla"` syntax, allowing to join two db tables with the same name.
The change in https://github.com/openspending/babbage/commit/53e20b6710322d6ff83794ea5ee566a72af86f7f extended that to a 2-string array, detailing the names of the two columns in the two tables.
