### PR TITLE
Add entrypoint script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 install:
   # Will build local Dockerfile as part of ci-run (docker-compose up)
   - make ci-run
-  - pip install tox coveralls 'datapackage-pipelines[speedup]>=1.6.18,<1.7' datapackage-pipelines-fiscal psycopg2-binary
+  - pip install tox coveralls 'datapackage-pipelines[speedup]>=1.6.18,<1.7' datapackage-pipelines-fiscal==1.0.14 psycopg2-binary
 
 before_script:
   - sleep 30

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,11 @@ WORKDIR /app
 ADD requirements.txt .
 RUN pip install -r requirements.txt
 
+COPY docker/entrypoint.sh /entrypoint.sh
+
 ADD . .
 
 EXPOSE 8000
 
-ENTRYPOINT ["gunicorn"]
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["-t 120", "-w 4", "os_api.app:app", "-b 0.0.0.0:8000"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+# This script is the entrypoint to the os-conductor Docker container. This will
+# verify that the Elasticsearch environment variable is set and that
+# Elasticsearch is running before executing the command provided to the docker
+# container.
+
+# Read parameters from the environment and validate them.
+checkHost() {
+    if [ -z "$$1" ]; then
+        echo >&2 'Error: missing required $1 environment variable'
+        echo >&2 '  Did you forget to -e $1=... ?'
+        exit 1
+    fi
+}
+
+readParams() {
+  checkHost "OS_ELASTICSEARCH_ADDRESS"
+}
+
+# Wait for elasticsearch to start. It requires that the status be either green
+# or yellow.
+waitForElasticsearch() {
+  echo -n "Waiting on $1 to start."
+  for ((i=1;i<=300;i++))
+  do
+    health=$(curl --silent "http://$1/_cat/health" | awk '{print $4}')
+    if [[ "$health" == "green" ]] || [[ "$health" == "yellow" ]]
+    then
+      echo
+      echo "Elasticsearch is ready!"
+      return 0
+    fi
+
+    ((i++))
+    echo -n '.'
+    sleep 1
+  done
+
+  echo
+  echo >&2 'Elasticsearch is not running or is not healthy.'
+  echo >&2 "Address: ${OS_ELASTICSEARCH_ADDRESS}"
+  echo >&2 "$health"
+  exit 1
+}
+
+# Main
+readParams
+if [ ${OS_CHECK_ES_HEALTHY+x} ]
+then
+waitForElasticsearch $OS_ELASTICSEARCH_ADDRESS
+fi
+gunicorn $@


### PR DESCRIPTION
Ensures ElasticSearch is running before starting os-api. Useful for development, only runs if `OS_CHECK_ES_HEALTHY` is true. 

Also fixes travis build by specifying datapackage-pipelines-fiscal lib version.