### PR TITLE
Fix test install steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 install:
   # Will build local Dockerfile as part of ci-run (docker-compose up)
   - make ci-run
-  - pip install tox coveralls 'datapackage-pipelines[speedup]>=1.7.1' datapackage-pipelines-fiscal==1.1.0 psycopg2-binary
+  - pip install tox coveralls 'datapackage-pipelines[speedup]>=1.7.1,<2.0.0' datapackage-pipelines-fiscal==1.1.0 psycopg2-binary
 
 before_script:
   - sleep 30

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 install:
   # Will build local Dockerfile as part of ci-run (docker-compose up)
   - make ci-run
-  - pip install tox coveralls 'datapackage-pipelines[speedup]>=1.7.1,<2.0.0' datapackage-pipelines-fiscal==1.1.0 psycopg2-binary
+  - pip install tox coveralls 'cachetools>=2,<3' 'datapackage-pipelines[speedup]>=1.7.1,<2.0.0' datapackage-pipelines-fiscal==1.1.0 psycopg2-binary
 
 before_script:
   - sleep 30

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -9,12 +9,10 @@ services:
       OS_API_ENGINE: postgresql://postgres@db/postgres
       OS_ELASTICSEARCH_ADDRESS: es:9200
       OS_MQ_ADDRESS: mq
-
       OS_API_CACHE: redis
       OS_API_CACHE_TIMEOUT: 86400
       CELERY_CONFIG: amqp://guest:guest@mq:5672//
       CELERY_BACKEND_CONFIG: amqp://guest:guest@mq:5672//
-
       OS_CHECK_ES_HEALTHY: 'True'
     restart: always
     depends_on:

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
   pytest-cov
   pytest-flask
   coverage
-  datapackage-pipelines>=1.7.1
+  datapackage-pipelines>=1.7.1,<2.0.0
   datapackage-pipelines-fiscal
 commands =
   pytest \


### PR DESCRIPTION
dpp 1.7.1 uses cachetools. If cachetools version 3 is install, the pipeline fails at join. Explicitly specify cachetools v2.x is used. See https://github.com/frictionlessdata/datapackage-pipelines/issues/155 for details.